### PR TITLE
AV-932: Disallow creating datasets into non-approved organizations

### DIFF
--- a/ckanext/organizationapproval/auth.py
+++ b/ckanext/organizationapproval/auth.py
@@ -1,0 +1,19 @@
+from ckan.plugins import toolkit
+import logging
+
+log = logging.getLogger(__name__)
+
+
+@toolkit.chained_auth_function
+def package_create(next_auth, context, data_dict):
+    if data_dict is None:
+        return {'success': True}
+
+    owner_org = data_dict.get('owner_org')
+
+    if not owner_org:
+        return {'success': True}
+
+    organization = toolkit.get_action('organization_show')(context, {'id': owner_org})
+    approved = organization.get('approval_status') == 'approved'
+    return {'success': approved}

--- a/ckanext/organizationapproval/plugin.py
+++ b/ckanext/organizationapproval/plugin.py
@@ -3,6 +3,7 @@ import os
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 from helpers import make_pager_url
+import auth
 
 
 class OrganizationApprovalPlugin(plugins.SingletonPlugin):
@@ -10,6 +11,7 @@ class OrganizationApprovalPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IRoutes, inherit=True)
     plugins.implements(plugins.ITranslation)
+    plugins.implements(plugins.IAuthFunctions)
 
     # IConfigurer
     def update_config(self, config_):
@@ -71,3 +73,6 @@ class OrganizationApprovalPlugin(plugins.SingletonPlugin):
         ckanext-{extension name}, hence your pot, po and mo files should be
         named ckanext-{extension name}.mo'''
         return 'ckanext-{name}'.format(name=self.name)
+
+    def get_auth_functions(self):
+        return {'package_create': auth.package_create}


### PR DESCRIPTION
- Add a chained `package_create`auth function to fail adding packages to non-approved organizations