### PR TITLE
AV-1640: Fix organization approval pagination and show pending orgs first

### DIFF
--- a/ckanext/organizationapproval/helpers.py
+++ b/ckanext/organizationapproval/helpers.py
@@ -2,6 +2,5 @@ from ckan.lib import helpers
 
 
 def make_pager_url(q=None, page=None):
-    ctrlr = 'ckanext.organizationapproval.controller:OrganizationApprovalController'
-    url = helpers.url_for(controller=ctrlr, action='manage_organizations')
+    url = helpers.url_for("organizationapproval.manage_organizations")
     return url + '?page=' + str(page)

--- a/ckanext/organizationapproval/templates/admin/manage_organizations.html
+++ b/ckanext/organizationapproval/templates/admin/manage_organizations.html
@@ -12,8 +12,8 @@
   <ul class="list-group">
     <!-- TODO: probably filter out already approved organizations -->
     <!-- or add an option to show only unapproved organizations -->
-    {% if c.organization_data %}
-      {% for organization in c.organization_data %}
+    {% if organization_data %}
+      {% for organization in organization_data %}
         {% set status_classes = {'pending': 'info', 'denied': 'warning', 'approved': 'success'} %}
         {% set status_class = status_classes[organization.approval_status] %}
         <li class="list-group-item">
@@ -82,9 +82,9 @@
     {% endif %}
   </ul>
 
-  <!-- TODO: replace predefined link values with fetched link values -->
-  <!-- This could also be a template function that gets total pages, current page and link -->
-  <!-- Just noticed theres a pager function that is used on other pages with pagination -->
+  {# TODO: replace predefined link values with fetched link values #}
+  {# This could also be a template function that gets total pages, current page and link #}
+  {# Just noticed theres a pager function that is used on other pages with pagination #}
   {% if total_pages > 1 %}
     <nav aria-label="Page navigation">
       <ul class="pagination">

--- a/ckanext/organizationapproval/utils.py
+++ b/ckanext/organizationapproval/utils.py
@@ -1,0 +1,29 @@
+from ckan.plugins import toolkit
+import itertools
+
+def organization_generator(context, options=None, page_size: int=None) -> list:
+    if options is None:
+        options = {}
+    if page_size is None:
+        # Default value for ckan.group_and_organization_list_max is 25
+        page_size = toolkit.config.get('ckan.group_and_organization_list_max', 25)
+
+    organization_list = toolkit.get_action('organization_list')
+
+    # Loop through all items. Each page has {page_size} items.
+    # Stop iteration when all items have been looped.
+    for index in itertools.count(start=0, step=page_size):
+        data_dict = options.copy()
+        data_dict.update({'limit': page_size, 'offset': index})
+        organizations = organization_list(context, data_dict)
+
+        # Empty page, previous must have been the last one
+        if not organizations:
+            return
+
+        for organization in organizations:
+            yield organization
+
+        # Incomplete page, must be the last one
+        if len(organizations) < page_size:
+            return

--- a/ckanext/organizationapproval/utils.py
+++ b/ckanext/organizationapproval/utils.py
@@ -1,7 +1,8 @@
 from ckan.plugins import toolkit
 import itertools
 
-def organization_generator(context, options=None, page_size: int=None) -> list:
+
+def organization_generator(context, options=None, page_size: int = None) -> list:
     if options is None:
         options = {}
     if page_size is None:

--- a/ckanext/organizationapproval/views.py
+++ b/ckanext/organizationapproval/views.py
@@ -4,6 +4,7 @@ from ckan import model
 from math import ceil
 import logging
 from .logic import send_organization_approved, send_organization_denied
+from .utils import organization_generator
 
 log = logging.getLogger(__name__)
 _ = toolkit._
@@ -61,7 +62,7 @@ def manage_organizations():
     # NOTE: This might cause slowness, get's all organizations and they are filtered later.
     # Organization list action doesn't support sorting by any field.
     # Maybe would be better to build a custom action for this case.
-    organization_list = toolkit.get_action('organization_list')(context, {"all_fields": True})
+    organization_list = list(organization_generator(context, {"all_fields": True}))
 
     page_num = 1
     per_page = 50.0
@@ -73,13 +74,14 @@ def manage_organizations():
         page_num = int(request.args['page'])
 
     # Return 20 most recently added organizations
-    toolkit.c.organization_data = sorted(organization_list, key=lambda x: x['created'], reverse=True)[
+    organization_data = sorted(organization_list, key=lambda x: (x['approval_status'], x['created']), reverse=True)[
         (int(per_page) * (page_num - 1)):(int(per_page) * page_num)
     ]
 
     return toolkit.render('admin/manage_organizations.html', extra_vars={
         'current_page': page_num,
         'total_pages': total_pages,
+        'organization_data': organization_data
     })
 
 


### PR DESCRIPTION
`organization_list` does not return all organizations by default, this replaces it with generator. However this will still fetch all of them as `organization_list` does not support sorting by defined field.

Sorts pending organizations first so they are easily discoverable.

Fixes pagination in the UI as well which was broken after migration.